### PR TITLE
Map fixes

### DIFF
--- a/components/FriendPin.js
+++ b/components/FriendPin.js
@@ -19,6 +19,7 @@ const FriendPin = (props) => {
             }}
             onMouseOver={() => {
                 props.setSelectedFriend(props.friend);
+                props.setAddingFriend(null);
             }}>
             <path d={ICON} />
 

--- a/components/NewFriend.js
+++ b/components/NewFriend.js
@@ -29,6 +29,7 @@ const NewFriend = (props) => {
                 console.log('Friend added: ', newFriend);
                 props.setUpdated(!(props.updated));
                 props.setAddingFriend(false);
+                props.setMarker(null);
             });
         } catch (error) {
             console.log('Failed to add Friend', error);
@@ -50,7 +51,7 @@ const NewFriend = (props) => {
             </label>
             <p>Lat: {marker.latitude}</p>
             <p>Long: {marker.longitude}</p>
-            <button type="submit">Add Friend</button>
+            <button type="submit" value={"preventNewMarker"}>Add Friend</button>
         </form>
     );
 };

--- a/components/Pin.js
+++ b/components/Pin.js
@@ -15,7 +15,8 @@ const Pin = (props) => {
     return (
         <svg height={size} viewBox="0 0 24 24" style={pinStyle}
             onMouseOver={() => {
-                props.setAddingFriend(true);
+                (!props.selectedFriend) ? props.setAddingFriend(true) :
+                    props.setSelectedFriend(null);
             }}>
             <path d={ICON} />
 

--- a/pages/account/Friends.js
+++ b/pages/account/Friends.js
@@ -118,7 +118,10 @@ const Friends = () => {
                             <Popup
                                 latitude={marker.latitude}
                                 longitude={marker.longitude}
-                                onClose={() => setAddingFriend(false)}
+                                onClose={() => {
+                                    setAddingFriend(false)
+                                    setMarker(null)
+                                }}
                                 closeOnClick={true}>
                                 <NewFriend
                                     marker={marker}

--- a/pages/account/Friends.js
+++ b/pages/account/Friends.js
@@ -115,9 +115,6 @@ const Friends = () => {
                                     selectedFriend={selectedFriend}
                                     setSelectedFriend={setSelectedFriend}>
                                 </Pin>
-                                <button onClick={() => setDisplayInfoCard(!displayInfoCard)}>
-                                    {displayInfoCard ? "Hide Friends" : "Show Friends"}
-                                </button>
                             </Marker>
                         }
 
@@ -178,20 +175,25 @@ const Friends = () => {
                     </ReactMapGL>
                 </div>
 
-                {displayInfoCard &&
-                    <div className={styles.card}>
-                        {friendList.map(friend => (
-                            <div key={friend._id}>
-                                <p>{friend.name}</p>
-                                <p>{friend.coordinates.latitude}</p>
-                                <p>{friend.coordinates.longitude}</p>
-                                <p>{friend.timezone}</p>
-                                <p>{friend.timezone_offset}</p>
-                                <hr></hr>
-                            </div>
-                        ))}
-                    </div>
-                }
+                <div>
+                    <button onClick={() => setDisplayInfoCard(!displayInfoCard)}>
+                        {displayInfoCard ? "Hide Friends" : "Show Friends"}
+                    </button>
+                    {displayInfoCard &&
+                        <div className={styles.card}>
+                            {friendList.map(friend => (
+                                <div key={friend._id}>
+                                    <p>{friend.name}</p>
+                                    <p>{friend.coordinates.latitude}</p>
+                                    <p>{friend.coordinates.longitude}</p>
+                                    <p>{friend.timezone}</p>
+                                    <p>{friend.timezone_offset}</p>
+                                    <hr></hr>
+                                </div>
+                            ))}
+                        </div>
+                    }
+                </div>
             </div>
         </div>
     );

--- a/pages/account/Friends.js
+++ b/pages/account/Friends.js
@@ -70,22 +70,25 @@ const Friends = () => {
     // Update the map clicks for newFriendMarker
     const handleClick = (e) => {
         e.preventDefault();
+        const isAddOrDelete = e.target.value;
         // Parse coordinates for api compatibility
-        const longitude = parseFloat((e.lngLat[0]).toFixed(4));
-        const latitude = parseFloat((e.lngLat[1]).toFixed(4));
-        setMarker({
-            longitude: longitude,
-            latitude: latitude
-        });
-
-        // Get timezone info
-        fetchAPI(latitude, longitude)
-            .then((data) => {
-                console.log('resolved');
-                setData(data);
-            }).catch((error) => {
-                console.log('rejected', error);
+        if (!isAddOrDelete) {
+            const longitude = parseFloat((e.lngLat[0]).toFixed(4));
+            const latitude = parseFloat((e.lngLat[1]).toFixed(4));
+            setMarker({
+                longitude: longitude,
+                latitude: latitude
             });
+
+            // Get timezone info
+            fetchAPI(latitude, longitude)
+                .then((data) => {
+                    console.log('resolved');
+                    setData(data);
+                }).catch((error) => {
+                    console.log('rejected', error);
+                });
+        }
     };
 
     return (
@@ -107,7 +110,11 @@ const Friends = () => {
                                 offsetTop={-20}
                                 offsetLeft={-10}
                                 anchor={"top-left"}>
-                                <Pin setAddingFriend={setAddingFriend} size={20}></Pin>
+                                <Pin setAddingFriend={setAddingFriend}
+                                    size={20}
+                                    selectedFriend={selectedFriend}
+                                    setSelectedFriend={setSelectedFriend}>
+                                </Pin>
                                 <button onClick={() => setDisplayInfoCard(!displayInfoCard)}>
                                     {displayInfoCard ? "Hide Friends" : "Show Friends"}
                                 </button>
@@ -119,8 +126,8 @@ const Friends = () => {
                                 latitude={marker.latitude}
                                 longitude={marker.longitude}
                                 onClose={() => {
-                                    setAddingFriend(false)
-                                    setMarker(null)
+                                    setAddingFriend(false);
+                                    setMarker(null);
                                 }}
                                 closeOnClick={true}>
                                 <NewFriend
@@ -129,6 +136,7 @@ const Friends = () => {
                                     updated={updated}
                                     user={user}
                                     setAddingFriend={setAddingFriend}
+                                    setMarker={setMarker}
                                     data={data}>
                                 </NewFriend>
                             </Popup>
@@ -143,6 +151,7 @@ const Friends = () => {
                                     offsetTop={-20}
                                     offsetLeft={-10}>
                                     <FriendPin setSelectedFriend={setSelectedFriend}
+                                        setAddingFriend={setAddingFriend}
                                         size={20}
                                         friend={friend}>
                                     </FriendPin>


### PR DESCRIPTION
1. Moved show/hide friends button from map to side
2. Clicking add/delete friends button no longer sets a NewFriend pin
3. Closing addingFriend popup now resets the pin, and removes it from the map